### PR TITLE
Prevent potential Java 21 issue

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -20,6 +20,7 @@ dependencies {
 
     implementation("org.openrewrite:rewrite-java")
     runtimeOnly("org.openrewrite:rewrite-java-17")
+    runtimeOnly("org.openrewrite:rewrite-java-21")
     // Need to have a slf4j binding to see any output enabled from the parser.
     runtimeOnly("ch.qos.logback:logback-classic:1.2.+")
 
@@ -29,4 +30,10 @@ dependencies {
 
     testImplementation("org.openrewrite:rewrite-test")
     testImplementation("org.assertj:assertj-core:latest.release")
+}
+
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(21))
+    }
 }

--- a/src/main/java/org/openrewrite/ai/DefaultComesLast.java
+++ b/src/main/java/org/openrewrite/ai/DefaultComesLast.java
@@ -50,8 +50,8 @@ public class DefaultComesLast extends Recipe {
                 GenerativeCodeEditor editor = new GenerativeCodeEditor(this::getCursor, ctx);
 
                 for (Statement statement : aSwitch.getCases().getStatements()) {
-                    if (statement instanceof J.Case && ((J.Case) statement).getExpressions().get(0) instanceof J.Identifier) {
-                        J.Identifier identifier = (J.Identifier) ((J.Case) statement).getExpressions().get(0);
+                    if (statement instanceof J.Case && ((J.Case) statement).getCaseLabels().get(0) instanceof J.Identifier) {
+                        J.Identifier identifier = (J.Identifier) ((J.Case) statement).getCaseLabels().get(0);
                         if ("default".equals(identifier.getSimpleName())) {
                             return editor.edit(
                                 aSwitch,


### PR DESCRIPTION
## What's changed?
<!-- A brief description of the changes in this pull request -->
Apply newest `getCaseLabel` instead of `getExpression`

## Anyone you would like to review specifically?
<!-- @mention them here -->
@timtebeek 

## Have you considered any alternatives or workarounds?
<!-- Any other ways to solve the problem, or ways to work around the problem. -->

## Any additional context
<!-- Any thoughts you would like to share in addition to the above. -->

### Checklist
- [ ] I've added unit tests to cover both positive and negative cases
- [x] I've read and applied the [recipe conventions and best practices](https://docs.openrewrite.org/authoring-recipes/recipe-conventions-and-best-practices)
- [x] I've used the IntelliJ IDEA auto-formatter on affected files
